### PR TITLE
Added compatibility to new Keras 2.2.0+

### DIFF
--- a/model_continue_train.py
+++ b/model_continue_train.py
@@ -30,7 +30,7 @@ from keras.utils import layer_utils
 from keras.utils.data_utils import get_file
 from keras.applications.imagenet_utils import decode_predictions
 from keras.applications.imagenet_utils import preprocess_input
-from keras.applications.imagenet_utils import _obtain_input_shape
+from keras_applications.imagenet_utils import _obtain_input_shape
 from keras.engine.topology import get_source_inputs
 from keras.callbacks import ModelCheckpoint
 from keras.optimizers import Adam


### PR DESCRIPTION
Updated the way to import _obtain_input_shape for Keras 2.2.0+

Reference: https://stackoverflow.com/questions/49113140/importerror-cannot-import-name-obtain-input-shape-from-keras